### PR TITLE
add turnout data extraction, totals, basic project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+data/*

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pandas = "*"
+xmltodict = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,118 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "ad640f457d45b4cfbbdb544b945cc0747d764c0628897c5645433bf0466855cd"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "numpy": {
+            "hashes": [
+                "sha256:0d60fbae8e0019865fc4784745814cff1c421df5afee233db6d88ab4f14655a2",
+                "sha256:1a1329e26f46230bf77b02cc19e900db9b52f398d6722ca853349a782d4cff55",
+                "sha256:1b9735c27cea5d995496f46a8b1cd7b408b3f34b6d50459d9ac8fe3a20cc17bf",
+                "sha256:2792d23d62ec51e50ce4d4b7d73de8f67a2fd3ea710dcbc8563a51a03fb07b01",
+                "sha256:3e0746410e73384e70d286f93abf2520035250aad8c5714240b0492a7302fdca",
+                "sha256:4c3abc71e8b6edba80a01a52e66d83c5d14433cbcd26a40c329ec7ed09f37901",
+                "sha256:5883c06bb92f2e6c8181df7b39971a5fb436288db58b5a1c3967702d4278691d",
+                "sha256:5c97325a0ba6f9d041feb9390924614b60b99209a71a69c876f71052521d42a4",
+                "sha256:60e7f0f7f6d0eee8364b9a6304c2845b9c491ac706048c7e8cf47b83123b8dbf",
+                "sha256:76b4115d42a7dfc5d485d358728cdd8719be33cc5ec6ec08632a5d6fca2ed380",
+                "sha256:7dc869c0c75988e1c693d0e2d5b26034644399dd929bc049db55395b1379e044",
+                "sha256:834b386f2b8210dca38c71a6e0f4fd6922f7d3fcff935dbe3a570945acb1b545",
+                "sha256:8b77775f4b7df768967a7c8b3567e309f617dd5e99aeb886fa14dc1a0791141f",
+                "sha256:90319e4f002795ccfc9050110bbbaa16c944b1c37c0baeea43c5fb881693ae1f",
+                "sha256:b79e513d7aac42ae918db3ad1341a015488530d0bb2a6abcbdd10a3a829ccfd3",
+                "sha256:bb33d5a1cf360304754913a350edda36d5b8c5331a8237268c48f91253c3a364",
+                "sha256:bec1e7213c7cb00d67093247f8c4db156fd03075f49876957dca4711306d39c9",
+                "sha256:c5462d19336db4560041517dbb7759c21d181a67cb01b36ca109b2ae37d32418",
+                "sha256:c5652ea24d33585ea39eb6a6a15dac87a1206a692719ff45d53c5282e66d4a8f",
+                "sha256:d7806500e4f5bdd04095e849265e55de20d8cc4b661b038957354327f6d9b295",
+                "sha256:db3ccc4e37a6873045580d413fe79b68e47a681af8db2e046f1dacfa11f86eb3",
+                "sha256:dfe4a913e29b418d096e696ddd422d8a5d13ffba4ea91f9f60440a3b759b0187",
+                "sha256:eb942bfb6f84df5ce05dbf4b46673ffed0d3da59f13635ea9b926af3deb76926",
+                "sha256:f08f2e037bba04e707eebf4bc934f1972a315c883a9e0ebfa8a7756eabf9e357",
+                "sha256:fd608e19c8d7c55021dffd43bfe5492fab8cc105cc8986f813f8c3c048b38760"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.25.2"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:0164b85937707ec7f70b34a6c3a578dbf0f50787f910f21ca3b26a7fd3363437",
+                "sha256:28f330845ad21c11db51e02d8d69acc9035edfd1116926ff7245c7215db57957",
+                "sha256:38f74ef7ebc0ffb43b3d633e23d74882bce7e27bfa09607f3c5d3e03ffd9a4a5",
+                "sha256:40dd20439ff94f1b2ed55b393ecee9cb6f3b08104c2c40b0cb7186a2f0046242",
+                "sha256:629124923bcf798965b054a540f9ccdfd60f71361255c81fa1ecd94a904b9dd3",
+                "sha256:62c24c7fc59e42b775ce0679cfa7b14a5f9bfb7643cfbe708c960699e05fb918",
+                "sha256:6e6a0fe052cf27ceb29be9429428b4918f3740e37ff185658f40d8702f0b3e09",
+                "sha256:70cf866af3ab346a10debba8ea78077cf3a8cd14bd5e4bed3d41555a3280041c",
+                "sha256:86f100b3876b8c6d1a2c66207288ead435dc71041ee4aea789e55ef0e06408cb",
+                "sha256:9d81e1813191070440d4c7a413cb673052b3b4a984ffd86b8dd468c45742d3cc",
+                "sha256:b31da36d376d50a1a492efb18097b9101bdbd8b3fbb3f49006e02d4495d4c644",
+                "sha256:b9a6ccf0963db88f9b12df6720e55f337447aea217f426a22d71f4213a3099a6",
+                "sha256:cda72cc8c4761c8f1d97b169661f23a86b16fdb240bdc341173aee17e4d6cedd",
+                "sha256:d4f38e4fedeba580285eaac7ede4f686c6701a9e618d8a857b138a126d067f2f",
+                "sha256:d53c8c1001f6a192ff1de1efe03b31a423d0eee2e9e855e69d004308e046e694",
+                "sha256:d8c58b1113892e0c8078f006a167cc210a92bdae23322bb4614f2f0b7a4b510f",
+                "sha256:d97daeac0db8c993420b10da4f5f5b39b01fc9ca689a17844e07c0a35ac96b4b",
+                "sha256:d99e678180bc59b0c9443314297bddce4ad35727a1a2656dbe585fd78710b3b9",
+                "sha256:eb20252720b1cc1b7d0b2879ffc7e0542dd568f24d7c4b2347cb035206936421"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.1.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588",
+                "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"
+            ],
+            "version": "==2023.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "tzdata": {
+            "hashes": [
+                "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a",
+                "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"
+            ],
+            "markers": "python_version >= '2'",
+            "version": "==2023.3"
+        },
+        "xmltodict": {
+            "hashes": [
+                "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56",
+                "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.4'",
+            "version": "==0.13.0"
+        }
+    },
+    "develop": {}
+}

--- a/script/combine_files.R
+++ b/script/combine_files.R
@@ -1,0 +1,33 @@
+#' Small script for combining election outcome files.
+#' 
+#' This script assumes it is located in: 
+#'   <project folder>/script
+#' 
+#' With accompanying data in:
+#'   <project folder>/data
+#' 
+#' It uses the `here` package to correctly set the working directory and find data files,
+#' provided these assumptions are met.
+#' 
+#' It recursively searches the data folder for any files ending in `turnout.csv`,
+#' loads each into memory, combines them into a single tibble, and parses the election
+#' name into a province name. 
+#' 
+#' Specifically, this script is written for the Dutch upper house elections of 2023
+#' (Provinciale Staten <province> 2023), and extracts the province name expecting this
+#' pattern. Adaptation to other elections should be straightforward.
+
+here::i_am("script/combine_files.R")
+library(here)
+library(tidyverse)
+
+turnout_files <- dir(here("data/"), pattern = "turnout.csv$", full.names = TRUE, recursive = TRUE)
+
+data <- turnout_files %>% 
+    purrr::map(vroom::vroom, show_col_types = FALSE, progress = FALSE, .progress = TRUE) %>%
+    purrr::list_rbind() %>%
+    mutate(
+        provincie = stringr::str_extract(contest_name, "Provinciale Staten (.*) 2023", group = 1)
+    )
+
+readr::write_csv(data, file = here("data/turnout.csv"))

--- a/script/parse_eml.py
+++ b/script/parse_eml.py
@@ -6,12 +6,12 @@ import pandas as pd
 DATA_FOLDER = Path('../data/')
 
 
-def read_eml(path):
+def read_eml(path: Path):
 
     """Convert EML file to dictionary"""
 
     try:
-        return xmltodict.parse(path.read_text())
+        return xmltodict.parse(path.read_text(encoding="utf-8"))
 
     except UnicodeDecodeError as e:
         print(path.name)
@@ -44,15 +44,26 @@ def parse_election_data(data):
 
     rows_aggregates = []
     rows_per_candidate = []
+    rows_turnout = []
 
     contest = (data['EML']
                    ['Count']
                    ['Election']
                    ['Contests']
                    ['Contest'])
+    
+    try:
+        contest_name = (data['EML']
+                            ['Count']
+                            ['Election']
+                            ['ElectionIdentifier']
+                            ['ElectionName'])
+    except KeyError:
+        contest_name = None
 
     try:
-        contest_name = contest['ContestIdentifier']['ContestName']
+        if not contest_name:
+            contest_name = contest['ContestIdentifier']['ContestName']
     except KeyError:
         contest_name = None
 
@@ -64,6 +75,76 @@ def parse_election_data(data):
     except KeyError:
         managing_authority = None
 
+    
+    # base row template
+    item = {
+        'contest_name': contest_name,
+        'managing_authority': managing_authority
+    }
+
+    # total row template
+    total_item = item.copy()
+    total_item["station_id"] = "TOTAL"
+    total_item["station_name"] = "TOTAL"
+
+    # extract top level totals
+    total = contest["TotalVotes"]
+    try:
+        results = total['Selection']
+    except TypeError:
+        results = []
+
+    # party votes
+    row_aggregate = total_item.copy()
+    for result in results:
+        if 'AffiliationIdentifier' in result.keys():
+            party_name = result['AffiliationIdentifier']['RegisteredName']
+            party_id = result['AffiliationIdentifier']['@Id']
+            if pd.isnull(party_name):
+                party_name = party_id
+            votes = int(result['ValidVotes'])
+            row_aggregate[party_name] = votes
+
+        # candidate votes
+        elif PER_CANDIDATE.lower() in ['y', 'yes']:
+            row_cand = total_item.copy()
+            row_cand['party_name'] = party_name
+            row_cand['party_id'] = party_id
+            candidate_id = (result['Candidate']
+                                    ['CandidateIdentifier']
+                                    ['@Id'])
+            row_cand['candidate_identifier'] = candidate_id
+            row_cand['votes'] = result['ValidVotes']
+            rows_per_candidate.append(row_cand)
+    
+    rows_aggregates.append(row_aggregate)
+
+    # turnout, counted, rejected, invalid votes
+    if TURNOUT.lower() in ['y', 'yes']:
+        turnout_row = total_item.copy()
+        
+        try:
+            turnout_row["cast"] = int(total["Cast"])
+            turnout_row["counted"] = int(total["TotalCounted"])
+
+            try:
+                for rejected in total["RejectedVotes"]:
+                    turnout_row["rejected: " + rejected["@ReasonCode"]] = int(rejected["#text"])
+            except KeyError:
+                pass
+                    
+            try:
+                for uncounted in total["UncountedVotes"]:
+                    turnout_row["uncounted: " + uncounted["@ReasonCode"]] = int(uncounted["#text"])
+            except KeyError:
+                pass
+
+            rows_turnout.append(turnout_row)
+        
+        except TypeError:
+            pass
+
+    # start per station votes
     try:
         stations = contest['ReportingUnitVotes']
     except KeyError:
@@ -73,32 +154,28 @@ def parse_election_data(data):
             'managing_authority': managing_authority,
             'station_name': None,
             'station_id': None
-            }]
+        }]
+        
 
     for station in stations:
-
-        item = {
-            'contest_name': contest_name,
-            'managing_authority': managing_authority
-            }
+        row_item = item.copy()
+        
+        try:
+            row_item['station_id'] = station['ReportingUnitIdentifier']['@Id']
+        except TypeError:
+            row_item['station_id'] = None
 
         try:
-            item['station_id'] = station['ReportingUnitIdentifier']['@Id']
+            row_item['station_name'] = station['ReportingUnitIdentifier']['#text']
         except TypeError:
-            item['station_id'] = None
-
-        try:
-            item['station_name'] = station['ReportingUnitIdentifier']['#text']
-        except TypeError:
-            item['station_name'] = None
+            row_item['station_name'] = None
 
         try:
             results = station['Selection']
         except TypeError:
             results = []
 
-        row_aggregate = item.copy()
-
+        row_aggregate = row_item.copy()
         for result in results:
 
             if 'AffiliationIdentifier' in result.keys():
@@ -119,10 +196,36 @@ def parse_election_data(data):
                 row_cand['candidate_identifier'] = candidate_id
                 row_cand['votes'] = result['ValidVotes']
                 rows_per_candidate.append(row_cand)
-
+        
         rows_aggregates.append(row_aggregate)
 
-    return (rows_aggregates, rows_per_candidate, contest_name, managing_authority)
+
+        if TURNOUT.lower() in ['y', 'yes']:
+            turnout_row = row_item.copy()
+            
+            try:
+                turnout_row["cast"] = int(station["Cast"])
+                turnout_row["counted"] = int(station["TotalCounted"])
+
+                try:
+                    for rejected in station["RejectedVotes"]:
+                        turnout_row["rejected: " + rejected["@ReasonCode"]] = int(rejected["#text"])
+                except KeyError:
+                    pass
+                        
+                try:
+                    for uncounted in station["UncountedVotes"]:
+                        turnout_row["uncounted: " + uncounted["@ReasonCode"]] = int(uncounted["#text"])
+                except KeyError:
+                    pass
+
+                rows_turnout.append(turnout_row)
+            
+            except TypeError:
+                pass
+
+
+    return (rows_aggregates, rows_per_candidate, rows_turnout, contest_name, managing_authority)
 
 
 def process_files():
@@ -139,13 +242,18 @@ def process_files():
         name = path.name.split('.')[0]
 
         data = read_eml(path)
-        (rows_aggregates, rows_per_candidate, contest_name, 
+        (rows_aggregates, rows_per_candidate, rows_turnout, contest_name, 
             managing_authority) = parse_election_data(data)
 
         if PER_CANDIDATE.lower() in ['y', 'yes']:
             filename = '{} per candidate.csv'.format(name)
             df = pd.DataFrame(rows_per_candidate)
-            df.to_csv(str(VOTE_COUNTS / filename), index=False)
+            df.to_csv(str(VOTE_COUNTS / filename), index=False, encoding="utf-8")
+
+        if TURNOUT.lower() in ['y', 'yes']:
+            filename = '{} turnout.csv'.format(name)
+            df = pd.DataFrame(rows_turnout)
+            df.to_csv(str(VOTE_COUNTS / filename), index=False, encoding="utf-8")
 
         filename = '{} aggregate.csv'.format(name)
         df = pd.DataFrame(rows_aggregates)
@@ -155,7 +263,7 @@ def process_files():
             ]
         columns = first_cols + [c for c in df.columns if c not in first_cols]
         df = df[columns]
-        df.to_csv(str(VOTE_COUNTS / filename), index=False)
+        df.to_csv(str(VOTE_COUNTS / filename), index=False, encoding="utf-8")
 
 
 def parse_candidates(data, rows):
@@ -271,7 +379,7 @@ def create_candidate_list():
     df = pd.DataFrame(rows)
 
     path = TARGET / 'candidates.csv'
-    df.to_csv(str(path), index=False)
+    df.to_csv(str(path), index=False, encoding="utf-8")
 
 
 if __name__ == '__main__':
@@ -285,6 +393,10 @@ if __name__ == '__main__':
     print('\nDo you also want to create a csv with results per candidate?')
     print('This will take up more disk space (~1GB)\n')
     PER_CANDIDATE = input('Per candidate (y/n): ')
+
+    print('\nDo you also want to create a csv with turnout, uncounted, and rejected votes?')
+    print('This will take up more disk space (~100MB)\n')
+    TURNOUT = input('Turnout (y/n): ')
 
     start = dt.datetime.now()
 


### PR DESCRIPTION
I realise the project is legacy, but we've made some improvements for collecting turnout data on the 2023 provincial elections based on your original script. 

Some additions and restructuring was done in `parse_eml.py`, files were placed in the expected locations (`script/`), a Pipfile was added to make dependencies specific, and a simple R script for combining results was added. Combining could easily be done in python, but the client for this update is more comfortable in R.